### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/cruizr/b91a787c-8f4a-41f0-b6fa-7828a4cd4706/c8b419cf-e301-40b5-81b0-3a25bacf5638/_apis/work/boardbadge/f2fe8e5e-519d-44cf-ab80-ff4717362fc4)](https://dev.azure.com/cruizr/b91a787c-8f4a-41f0-b6fa-7828a4cd4706/_boards/board/t/c8b419cf-e301-40b5-81b0-3a25bacf5638/Microsoft.RequirementCategory)
 "# PartsUnlimited.Shared" 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#533](https://dev.azure.com/cruizr/b91a787c-8f4a-41f0-b6fa-7828a4cd4706/_workitems/edit/533). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.